### PR TITLE
Accepts non argument procs for static values

### DIFF
--- a/lib/ioughta.rb
+++ b/lib/ioughta.rb
@@ -52,7 +52,7 @@ module Ioughta
         return enum_for(__method__, data) { data.length / 2 } unless block_given?
 
         data.each_slice(2).with_index do |(nom, lam), iota|
-          val = lam.arity == 2 ? lam.call(iota, nom) : lam.call(iota)
+          val = lam.call(* [iota, nom].take(lam.arity.abs))
           next if nom == SKIP_SYMBOL
           yield nom, val
         end

--- a/spec/ioughta_spec.rb
+++ b/spec/ioughta_spec.rb
@@ -75,7 +75,8 @@ describe Ioughta do
           :A, :_,
           :B, ->(i) { i ** 2 }, :C, :_,
           :D, ->(j) { j ** 3 }, :E, :F, :_,
-          :G, proc(&:itself)
+          :G, -> { 0.1 }, :H, :_,
+          :I, proc(&:itself)
       end
     end
 
@@ -90,7 +91,9 @@ describe Ioughta do
       expect(Foo::D).to eq(5 ** 3)
       expect(Foo::E).to eq(6 ** 3)
       expect(Foo::F).to eq(7 ** 3)
-      expect(Foo::G).to eq(9)
+      expect(Foo::G).to eq(0.1)
+      expect(Foo::H).to eq(0.1)
+      expect(Foo::I).to eq(12)
     end
   end
 


### PR DESCRIPTION
Go can intercept the iota definition with simple value.
I think simply remove arity checker works okay for it.
